### PR TITLE
Add nuget package sample

### DIFF
--- a/src/Demos/6-nuget-packages.fsx
+++ b/src/Demos/6-nuget-packages.fsx
@@ -1,0 +1,83 @@
+﻿#load "helpers.fsx"
+#load "credentials.fsx"
+
+open MBrace
+open MBrace.Azure
+open MBrace.Azure.Client
+open MBrace.Azure.Runtime
+
+(**
+ This tutorial illustrates using other nuget packages.  You download and reference the packages as normal
+ in your F# scripting, and the DLLs for the packages are automatically uploaded to the cloud workers
+ as needed.
+
+ In this sample, we use paket (http://fsprojects.fsharp.io/paket) as the tool to fetch packages from NuGet.
+ You can alternatively just reference any DLLs you like using normal nuget commands.
+ 
+ Before running, edit credentials.fsx to enter your connection strings.
+**)
+
+
+//------------------------------------------
+// Step 0. Get the package bootstrap. This is standard F# boiler plate for scripts that also get packages.
+
+System.Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
+
+if not (System.IO.File.Exists "paket.exe") then
+    let url = "https://github.com/fsprojects/Paket/releases/download/0.27.2/paket.exe" in use wc = new System.Net.WebClient() in let tmp = System.IO.Path.GetTempFileName() in wc.DownloadFile(url, tmp); System.IO.File.Move(tmp,"paket.exe");;
+
+//------------------------------------------
+// Step 1. Resolve and install the Math.NET Numerics packages. You 
+// can add any additional packages you like to this step.
+
+#r "paket.exe"
+
+Paket.Dependencies.Install """
+    source https://nuget.org/api/v2
+    nuget MathNet.Numerics
+    nuget MathNet.Numerics.FSharp
+""";;
+
+
+//------------------------------------------
+// Step 2. Reference and use the packages on the local machine
+
+#load @"packages/MathNet.Numerics.FSharp/MathNet.Numerics.fsx"
+
+open MathNet.Numerics
+open MathNet.Numerics.LinearAlgebra
+
+let m1 = Matrix<double>.Build.Random(1000,1000)
+let v1 = Vector<double>.Build.Random(1000)
+
+v1 * m1 
+
+//------------------------------------------
+// Step 3. Run the code on MBrace. Note that the DLLs from the packages are uploaded
+// automatically.
+
+// First connect to the cluster
+let config = 
+    { Configuration.Default with
+        StorageConnectionString = myStorageConnectionString
+        ServiceBusConnectionString = myServiceBusConnectionString }
+
+let cluster = Runtime.GetHandle(config)
+
+let invertRandomMatrices = 
+    [ for m in 1 .. 20 -> 
+        cloud { 
+          let m = Matrix<double>.Build.Random(200,200) 
+          return (m * m.Inverse()).L1Norm() } ]
+    |> Cloud.Parallel
+    |> cluster.RunAsTask
+
+cluster.ShowProcesses()
+
+invertRandomMatrices.Result
+
+cluster.GetProcess("f75ff09396994ccf971c776a3004c3ee").Kill()
+
+
+
+

--- a/src/Demos/6-nuget-packages.fsx
+++ b/src/Demos/6-nuget-packages.fsx
@@ -76,8 +76,3 @@ cluster.ShowProcesses()
 
 invertRandomMatrices.Result
 
-cluster.GetProcess("f75ff09396994ccf971c776a3004c3ee").Kill()
-
-
-
-

--- a/src/Demos/Demos.fsproj
+++ b/src/Demos/Demos.fsproj
@@ -65,6 +65,7 @@
     <None Include="3-comparing-threads-and-workers.fsx" />
     <None Include="4-parallel-web-download.fsx" />
     <None Include="5-cloud-streams.fsx" />
+    <None Include="6-nuget-packages.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
Add a sample that involves getting some nuget packages and using them. The sample inverts 20 random 200x200 matrices on the cluster and checks that the M*M.inverse() is approx. 1.0.

I added this sample because it's useful to remind people that they can go and get any nuget packages they like from within their data scripting code and MBrace arranges for the DLLs to get sent to the cluster.
