### PR TITLE
Process --> Job

### DIFF
--- a/src/Demos/2-distributing-work.fsx
+++ b/src/Demos/2-distributing-work.fsx
@@ -15,23 +15,26 @@ open MBrace.Azure.Runtime
 let cluster = Runtime.GetHandle(config)
 
 // create two jobs (but don't exeute them)
-let jobA = cloud { return "hello world from A" }
-let jobB = cloud { return 50 }
+let workflowA = cloud { return "hello world from A" }
+let workflowB = cloud { return 50 }
 
 // Compose both jobs into one
-let combinedJob = jobA <||> jobB
+let combinedWorkflow = workflowA <||> workflowB
 
 // Submit both jobs and get the answer of both as a tuple of (string * int)
-let a, b = combinedJob |> cluster.Run
+let a, b = combinedWorkflow |> cluster.Run
 
 // Now we can make many jobs
-let lotsOfJobs = [ 1 .. 50 ] |> List.map(fun number -> cloud { return sprintf "i'm job %d" number })
+let lotsOfWorkflows = [ 1 .. 50 ] |> List.map(fun number -> cloud { return sprintf "i'm job %d" number })
 
 // compose them all in parallel - this is analogous to Async.Parallel
-let jobOfLotsOfWork = lotsOfJobs |> Cloud.Parallel
+let lotsOfWorkAsOneWorkflow = lotsOfWorkflows |> Cloud.Parallel
+
+// Start the work as a cloud process
+let resultsJob = lotsOfWorkAsOneWorkflow |> cluster.CreateProcess
 
 // Get the results
-let results = jobOfLotsOfWork |> cluster.Run
+let results = resultsJob.AwaitResult()
 
 // Again, in shorthand
 let quickResults =

--- a/src/Demos/5-cloud-streams.fsx
+++ b/src/Demos/5-cloud-streams.fsx
@@ -21,7 +21,7 @@ let cluster = Runtime.GetHandle(config)
 open Nessos.Streams
 open MBrace.Streams
 
-let streamComputationProcess = 
+let streamComputationJob = 
     [| 1..100 |]
     |> CloudStream.ofArray
     |> CloudStream.map (fun num -> num * num)
@@ -32,10 +32,10 @@ let streamComputationProcess =
     |> cluster.CreateProcess
 
 // Check progress
-streamComputationProcess.ShowInfo()
+streamComputationJob.ShowInfo()
 
 // Look at the result
-streamComputationProcess.AwaitResult()
+streamComputationJob.AwaitResult()
 
 (** 
 
@@ -45,7 +45,7 @@ streamComputationProcess.AwaitResult()
 
 let numbers = [| for i in 1 .. 30 -> 50000000 |]
 
-let computePrimesProcess = 
+let computePrimesJob = 
     numbers
     |> CloudStream.ofArray
     |> CloudStream.map Sieve.getPrimes
@@ -54,8 +54,8 @@ let computePrimesProcess =
     |> cluster.CreateProcess // alteratively you can block on the result using cluster.Run
 
 // Check if the work is done
-computePrimesProcess.ShowInfo()
+computePrimesJob.ShowInfo()
 
 // Wait for the result
-let computePrimes = computePrimesProcess.AwaitResult()
+let computePrimes = computePrimesJob.AwaitResult()
 

--- a/src/Demos/6-nuget-packages.fsx
+++ b/src/Demos/6-nuget-packages.fsx
@@ -58,7 +58,7 @@ v1 * m1
 // First connect to the cluster
 let cluster = Runtime.GetHandle(config)
 
-let invertRandomMatricesProcess = 
+let invertRandomMatricesJob = 
     [ for m in 1 .. 20 -> 
         cloud { 
           let m = Matrix<double>.Build.Random(200,200) 
@@ -67,8 +67,8 @@ let invertRandomMatricesProcess =
     |> cluster.CreateProcess
 
 // Show the progress
-invertRandomMatricesProcess.ShowInfo()
+invertRandomMatricesJob.ShowInfo()
 
 // Await the result
-let invertRandomMatrices = invertRandomMatricesProcess.AwaitResult()
+let invertRandomMatrices = invertRandomMatricesJob.AwaitResult()
 

--- a/src/Demos/7-upload-cloud-data-as-blobs.fsx
+++ b/src/Demos/7-upload-cloud-data-as-blobs.fsx
@@ -41,7 +41,7 @@ let arrayOfData = [| for i in 0 .. 10 -> [| for j in 0 .. 1000 -> (i,j) |] |]
 let arrayOfDataInCloud = arrayOfData |> CloudArray.New |> cluster.Run
 
 // Now process the cloud array
-let lengthsOfCloudArrayProcess = 
+let lengthsJob = 
     arrayOfDataInCloud
     |> CloudStream.ofCloudArray
     |> CloudStream.map (fun n -> n.Length)
@@ -49,18 +49,18 @@ let lengthsOfCloudArrayProcess =
     |> cluster.CreateProcess
 
 // Check progress
-lengthsOfCloudArrayProcess.ShowInfo()
+lengthsJob.ShowInfo()
 
 // Check progress
-lengthsOfCloudArrayProcess.Completed
+lengthsJob.Completed
 
 // Acccess the result
-let lengthsOfCloudArray =  lengthsOfCloudArrayProcess.AwaitResult()
+let lengths =  lengthsJob.AwaitResult()
 
 // Now process the cloud array again, using CloudStream.
 // We process each element of the cloud array (each of which is itself an array).
 // We then sort the results and take the top 10 elements
-let sumAndSortProcess = 
+let sumAndSortJob = 
     arrayOfDataInCloud
     |> CloudStream.ofCloudArray
     |> CloudStream.map (Array.sumBy (fun (i,j) -> i+j))
@@ -69,12 +69,12 @@ let sumAndSortProcess =
     |> cluster.CreateProcess
 
 // Check progress
-sumAndSortProcess.ShowInfo()
+sumAndSortJob.ShowInfo()
 
 // Check progress
-sumAndSortProcess.Completed
+sumAndSortJob.Completed
 
 // Acccess the result
-let sumAndSort = sumAndSortProcess.AwaitResult()
+let sumAndSort = sumAndSortJob.AwaitResult()
 
 

--- a/src/Demos/8-using-cloud-files.fsx
+++ b/src/Demos/8-using-cloud-files.fsx
@@ -55,7 +55,7 @@ Now we generate a collection of cloud files and process them using cloud streams
 **)
 
 // Generate 100 cloud files in the cloud storage
-let namedCloudFilesProcess = 
+let namedCloudFilesJob = 
     [ for i in 1 .. 100 do 
         // Note that we generate the contents of the files in the cloud - this cloud
         // computation below only captures and sends an integer.
@@ -66,12 +66,12 @@ let namedCloudFilesProcess =
    |> cluster.CreateProcess
 
 // Check progress
-namedCloudFilesProcess.ShowInfo()
+namedCloudFilesJob.ShowInfo()
 
 // Get the result
-let namedCloudFiles = namedCloudFilesProcess.AwaitResult()
+let namedCloudFiles = namedCloudFilesJob.AwaitResult()
 
-let sumOfLengthsOfLinesProcess = 
+let sumOfLengthsOfLinesJob = 
     namedCloudFiles
     |> CloudStream.ofCloudFiles CloudFile.ReadAllLines
     |> CloudStream.map (fun lines -> lines |> Array.sumBy (fun line -> line.Length))
@@ -80,9 +80,9 @@ let sumOfLengthsOfLinesProcess =
 
 
 // Check progress
-sumOfLengthsOfLinesProcess.ShowInfo()
+sumOfLengthsOfLinesJob.ShowInfo()
 
 // Get the result
-let sumOfLengthsOfLines = sumOfLengthsOfLinesProcess.AwaitResult()
+let sumOfLengthsOfLines = sumOfLengthsOfLinesJob.AwaitResult()
 
 


### PR DESCRIPTION
This normalizes the samples on the nice and short "Job" prefix for handles to stuff running in the cloud. And "Workflow" for `cloud { ... }` values.

I think `Job` is a better prefix than "Proc" - the `Proc` prefix can actually be confusing to people because they might think it's a operating system process in some way.  It's OK for MBrace to use it in the API of course but these beginner scripts are better off using the neutral and shorter `Job` for prefixes in process-typed value names I think
