### PR TITLE
General updates and new example showing building a serializable abstraction

### DIFF
--- a/src/Demos/11-distributed-multicore-parallel-search.fsx
+++ b/src/Demos/11-distributed-multicore-parallel-search.fsx
@@ -29,8 +29,10 @@ let cluster = Runtime.GetHandle(config)
 /// according to the number of available cores, and then performing sequential
 /// search on each machine.
 let distributedMultiCoreTryFind (predicate : 'T -> bool) (ts : 'T []) =
+
     // sequential single-threaded search
     let sequentialTryFind (ts : 'T []) = local { return Array.tryFind predicate ts }
+
     // local multicore parallel search
     let localmultiCoreTryFind (ts : 'T []) = local {
         if ts.Length <= 1 then return! sequentialTryFind ts

--- a/src/Demos/12-norvig's-spelling-corrector.fsx
+++ b/src/Demos/12-norvig's-spelling-corrector.fsx
@@ -43,8 +43,9 @@ let download (uri: string) = cloud {
         |> Array.chunkBySize 10000
         |> Array.mapi (fun index lines -> 
              local { 
-                try do! CloudFile.Delete(path = sprintf "text/%d.txt" index) with _ -> ()
-                return! CloudFile.WriteAllLines(lines, path = sprintf "text/%d.txt" index) })
+                do! CloudFile.Delete(path = sprintf "text/%d.txt" index) 
+                let! file = CloudFile.WriteAllLines(lines, path = sprintf "text/%d.txt" index) 
+                return file })
         |> Local.Parallel
     return files
 }

--- a/src/Demos/13-creating-new-serialized-things.fsx
+++ b/src/Demos/13-creating-new-serialized-things.fsx
@@ -44,7 +44,7 @@ type CloudThing (data:string) =
 
 
 //---------------------------------------------------------------------------
-// Now use the serialiable thing on the cluster
+// Now use the serializable thing on the cluster
 
 // First connect to the cluster
 let cluster = MBrace.Azure.Client.Runtime.GetHandle(config)

--- a/src/Demos/13-creating-new-serialized-things.fsx
+++ b/src/Demos/13-creating-new-serialized-things.fsx
@@ -21,7 +21,7 @@ any cloud or web asset that can be referred to by name.
 
 [<AutoSerializable(true) ; Sealed; DataContract>]
 /// An abstract item that you want to be transparently serializable to the cluster
-type SerializableThing (data:string) =
+type CloudThing (data:string) =
     
     [<DataMember(Name = "Data")>]
     // The core data of the item
@@ -51,8 +51,8 @@ let cluster = MBrace.Azure.Client.Runtime.GetHandle(config)
 
 
 // The values to serialize
-let data1 = SerializableThing("hello")
-let data2 = SerializableThing("goodbye")
+let data1 = CloudThing("hello")
+let data2 = CloudThing("goodbye")
 
 let job = 
   cloud { do! Cloud.Sleep 1000

--- a/src/Demos/13-creating-new-serialized-things.fsx
+++ b/src/Demos/13-creating-new-serialized-things.fsx
@@ -10,11 +10,8 @@ open MBrace.Azure
 
 (** 
 
-This tutorial shows you how to build a new serializable abstraction for another cloud
-asset referred to by name.  In this case we build an abstraction over an Azure storage queue (not
-an Azure service bus queue, which is a different beast).  Similar techniques can be used for
-any cloud or web asset that can be referred to by name.
-
+This tutorial shows you how to build a new serializable abstraction, e.g. 
+for another cloud asset referred to by name.  
 
 **)
 

--- a/src/Demos/13-creating-new-serialized-things.fsx
+++ b/src/Demos/13-creating-new-serialized-things.fsx
@@ -8,31 +8,55 @@ open System.Runtime.Serialization
 open MBrace
 open MBrace.Azure
 
-// First connect to the cluster
-let cluster = MBrace.Azure.Client.Runtime.GetHandle(config)
+(** 
+
+This tutorial shows you how to build a new serializable abstraction for another cloud
+asset referred to by name.  In this case we build an abstraction over an Azure storage queue (not
+an Azure service bus queue, which is a different beast).  Similar techniques can be used for
+any cloud or web asset that can be referred to by name.
+
+
+**)
 
 
 [<AutoSerializable(true) ; Sealed; DataContract>]
+/// An abstract item that you want to be transparently serializable to the cluster
 type SerializableThing (data:string) =
     
     [<DataMember(Name = "Data")>]
+    // The core data of the item
     let data = data
 
     [<IgnoreDataMember>]
+    // Some derived data for the item
     let mutable derivedData = data.Length
 
     [<OnDeserialized>]
     let _onDeserialized (_ : StreamingContext) =
+        // Re-establish the derived data on de-serialization
         derivedData <- data.Length
 
+    /// Access the core data
     member __.Data = data
+
+    /// Access the derived data
     member __.DerivedData = derivedData
 
-let data = SerializableThing("hello")
+
+//---------------------------------------------------------------------------
+// Now use the serialiable thing on the cluster
+
+// First connect to the cluster
+let cluster = MBrace.Azure.Client.Runtime.GetHandle(config)
+
+
+// The values to serialize
+let data1 = SerializableThing("hello")
+let data2 = SerializableThing("goodbye")
 
 let job = 
   cloud { do! Cloud.Sleep 1000
-          return data.Data, data.DerivedData }
+          return data1.Data, data1.DerivedData, data2 }
    |> cluster.CreateProcess
      
 

--- a/src/Demos/13-creating-new-serialized-things.fsx
+++ b/src/Demos/13-creating-new-serialized-things.fsx
@@ -1,0 +1,41 @@
+﻿#load "credentials.fsx"
+#r "System.Runtime.Serialization"
+
+open System
+open System.IO
+open System.Runtime.Serialization
+
+open MBrace
+open MBrace.Azure
+
+// First connect to the cluster
+let cluster = MBrace.Azure.Client.Runtime.GetHandle(config)
+
+
+[<AutoSerializable(true) ; Sealed; DataContract>]
+type SerializableThing (data:string) =
+    
+    [<DataMember(Name = "Data")>]
+    let data = data
+
+    [<IgnoreDataMember>]
+    let mutable derivedData = data.Length
+
+    [<OnDeserialized>]
+    let _onDeserialized (_ : StreamingContext) =
+        derivedData <- data.Length
+
+    member __.Data = data
+    member __.DerivedData = derivedData
+
+let data = SerializableThing("hello")
+
+let job = 
+  cloud { do! Cloud.Sleep 1000
+          return data.Data, data.DerivedData }
+   |> cluster.CreateProcess
+     
+
+job.ShowInfo()
+job.Completed
+job.AwaitResult()

--- a/src/Demos/2-distributing-work.fsx
+++ b/src/Demos/2-distributing-work.fsx
@@ -19,24 +19,12 @@ open Nessos.Streams
 // First connect to the cluster
 let cluster = Runtime.GetHandle(config)
 
-// create two jobs (but don't execute them)
-let workflowA = cloud { return "hello world from A" }
-let workflowB = cloud { return 50 }
-
-// Compose both jobs into one
-let combinedWorkflow = workflowA <||> workflowB
-
-// Submit both jobs and get the answer of both as a tuple of (string * int)
-let a, b = combinedWorkflow |> cluster.Run
-
-// Now we can make many jobs
-let lotsOfWorkflows = [ 1 .. 50 ] |> List.map(fun number -> cloud { return sprintf "i'm job %d" number })
-
-// compose them all in parallel - this is analogous to Async.Parallel
-let lotsOfWorkAsOneWorkflow = lotsOfWorkflows |> Cloud.Parallel
-
-// Start the work as a cloud process
-let resultsJob = lotsOfWorkAsOneWorkflow |> cluster.CreateProcess
+// Now we can make 50 jobs and compose them in parallel.
+let resultsJob = 
+    [ 1 .. 50 ] 
+    |> List.map(fun i -> cloud { return sprintf "i'm job %d" i })
+    |> Cloud.Parallel
+    |> cluster.CreateProcess
 
 cluster.ShowProcesses()
 
@@ -46,7 +34,15 @@ let results = resultsJob.AwaitResult()
 // Again, in shorthand
 let quickResults =
     [ 1 .. 50 ]
-    |> List.map(fun number -> cloud { return sprintf "i'm job %d" number })
+    |> List.map(fun i -> cloud { return sprintf "i'm job %d" i })
     |> Cloud.Parallel
+    |> cluster.Run
+
+// This shows the next composition combinator: Cloud.Choice, which does
+// non-deterministic choice among a collection of workers.
+let quickSearch =
+    [ 1 .. 50 ]
+    |> List.map(fun i -> cloud { if i % 10 = 0 then return Some i else return None } )
+    |> Cloud.Choice
     |> cluster.Run
 

--- a/src/Demos/3-comparing-threads-and-workers.fsx
+++ b/src/Demos/3-comparing-threads-and-workers.fsx
@@ -27,11 +27,8 @@ let cluster = Runtime.GetHandle(config)
 
 #time "on"
 
-// Get the current thread
-let getThread() = System.Threading.Thread.CurrentThread.ManagedThreadId
-
-// Specifies 30 jobs, each computing all the primes up to 5million 
-let numbers = [| for i in 1 .. 30 -> 50000000 |]
+// Specifies 30 jobs, each computing all the primes up to 100 million 
+let numbers = [| for i in 1 .. 30 -> 100000000 |]
 
 
 (**
@@ -41,69 +38,36 @@ let numbers = [| for i in 1 .. 30 -> 50000000 |]
  In each case, you calculate a whole bunch of primes.
 
 **)
+
+
 // Run this work in different ways on the local machine and cluster
 
 // Run on your local machine, single-threaded.
 //
 // Performance will depend on the spec of your machine. Note that it is possible that 
 // your machine is more efficient than each individual machine in the cluster.
-let localMachineSingleThreaded =
+let locallyComputedPrimes =
     numbers
     |> Array.map(fun num -> 
          let primes = Sieve.getPrimes num
-         sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()))
+         sprintf "calculated %d primes: %A" primes.Length primes )
 
 // Run in parallel on the cluster, on multiple workers, each single-threaded. This exploits the
-// the multiple machines (workers) in the cluster but each worker is running single-threaded.
+// the multiple machines (workers) in the cluster.
 //
 // Sample time: Real: 00:00:16.269, CPU: 00:00:02.906, GC gen0: 47, gen1: 44, gen2: 1
-let clusterMultiWorkerSingleThreaded =
+let clusterPrimesJob =
     numbers
     |> Array.map(fun num -> 
          cloud { let primes = Sieve.getPrimes num
-                 return sprintf "calculated %d primes %A on machine '%s' thread %d" primes.Length primes Environment.MachineName (getThread()) })
+                 return sprintf "calculated %d primes %A on machine '%s'" primes.Length primes Environment.MachineName })
     |> Cloud.Parallel
-    |> cluster.Run
+    |> cluster.CreateProcess
 
 
-(**
+cluster.ShowProcesses()
+let clusterPrimes = clusterPrimesJob.AwaitResult()
 
- More advanced comparisons.
-
- In each case, you still calculate a whole bunch of primes.
-
-**)
-
-// Run in the cluster, single threaded, on a single random worker.
-//
-// This doesn't exploit the multiple worker nor multiple cores in the cluster, but gives you an
-// idea of the raw performance of the machines in the  cluster. Performance
-// will depend on the specification of your machines in the cluster.
-//
-// Sample time: Real: 00:00:42.830, CPU: 00:00:03.843, GC gen0: 72, gen1: 11, gen2: 0
-let clusterSingleMachineSingleThreaded =
-    cloud { 
-     return numbers |> Array.map(fun n -> 
-             let primes = Sieve.getPrimes n 
-             sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()))
-     } |>  cluster.Run
-
-
-// Run in the cluster, on a single randome worker, multi-threaded. This exploits the
-// mutli-core nature of a single random machine in the cluster.  Performance
-// will depend on the specification of your machines in the cluster.
-//
-// Sample time: Real: 00:00:24.236, CPU: 00:00:03.000, GC gen0: 53, gen1: 10, gen2: 0
-let clusterSingleWorkerMultiThreaded =
-    cloud { 
-     return 
-       numbers
-       |> Array.splitInto System.Environment.ProcessorCount
-       |> Array.Parallel.collect(fun nums -> 
-         [| for n in nums do 
-             let primes = Sieve.getPrimes n 
-             yield sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()) |])
-     } |>  cluster.Run
 
 // Check how many cores one of the machines in the cluster has
 let clusterProcesorCountOfRandomWorker =
@@ -112,35 +76,5 @@ let clusterProcesorCountOfRandomWorker =
 // Check how many workers there are
 let clusterWorkerCount = cluster.GetWorkers() |> Seq.length
 
-// Run in the cluster, on multiple workers, each multi-threaded. This exploits the
-// the multiple machines (workers) in the cluster and each worker is running multi-threaded.
-//
-// We do the partitioning up-front.  
-//
-// Sample time: Real: 00:00:11.475, CPU: 00:00:01.921, GC gen0: 22, gen1: 12, gen2: 0
-let clusterMultiWorkerMultiThreaded =
-    numbers
-    |> Array.splitInto clusterWorkerCount
-    |> Array.map(fun nums -> 
-         cloud { 
-           return
-               nums
-               |> Array.splitInto System.Environment.ProcessorCount
-               |> Array.Parallel.collect(fun nums -> 
-                 [| for n in nums do 
-                     let primes = Sieve.getPrimes n 
-                     yield sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()) |])
-          })
-    |> Cloud.Parallel
-    |> cluster.Run
-
 // To complete the picture, you can also use a CloudStream programming model, see "5-cloud-streams.fsx"
 
-
-(*
-Some useful process control tips:
-
-cluster.ShowProcesses()
-cluster.ShowWorkers()
-cluster.GetProcess("5b729a7db6784dc191f645b14beede23").Kill()
-*)

--- a/src/Demos/4-parallel-web-download.fsx
+++ b/src/Demos/4-parallel-web-download.fsx
@@ -36,7 +36,8 @@ let write (text: string) (stream: Stream) = async {
 let download (name: string, uri: string) = cloud {
     let webClient = new WebClient()
     let! text = Cloud.OfAsync (webClient.AsyncDownloadString(Uri(uri)))
-    let! file = CloudFile.Create(write text, sprintf "pages/%s.html" name)
+    do! CloudFile.Delete(sprintf "pages/%s.html" name)
+    let! file = CloudFile.WriteAllText(text,path=sprintf "pages/%s.html" name)
     return file
 }
 

--- a/src/Demos/5-cloud-streams.fsx
+++ b/src/Demos/5-cloud-streams.fsx
@@ -21,7 +21,7 @@ open Nessos.Streams
 // First connect to the cluster
 let cluster = Runtime.GetHandle(config)
 
-// Streaming with Drayad-LINQ-style distributed operations. Note that the default is to partition
+// Parallel distributed data workflows. The default is to partition
 // the input work between all available workers.
 let streamComputationJob = 
     [| 1..100 |]
@@ -47,6 +47,10 @@ streamComputationJob.AwaitResult()
 
 let numbers = [| for i in 1 .. 30 -> 50000000 |]
 
+// The default is to partition the input array between all available workers.
+//
+// You can also use CloudStream.withDegreeOfParallelism to specify the degree
+// of partitioning of the stream at any point in the pipeline.
 let computePrimesJob = 
     numbers
     |> CloudStream.ofArray

--- a/src/Demos/8-using-cloud-files.fsx
+++ b/src/Demos/8-using-cloud-files.fsx
@@ -19,6 +19,9 @@ open Nessos.Streams
 // First connect to the cluster
 let cluster = Runtime.GetHandle(config)
 
+cluster.ShowProcesses()
+cluster.ShowWorkers()
+
 // Here's some data
 let linesOfFile = ["Hello World"; "How are you" ] 
 
@@ -44,7 +47,8 @@ let namedCloudFile =
         let lines = [for i in 0 .. 1000 -> "Item " + string i + ", " + string (i * 100) ] 
         let fileName = dp.Path + "/file1"
         do! CloudFile.Delete(fileName) 
-        return! CloudFile.WriteAllLines(lines, path = fileName) 
+        let! file = CloudFile.WriteAllLines(lines, path = fileName) 
+        return file
     } |> cluster.Run
 
 // Access the cloud file as part of a cloud job
@@ -53,6 +57,7 @@ let numberOfLinesInNamedFile =
             return data.Length }
     |> cluster.Run
 
+cluster.ShowLogs(240.0)
 
 (** 
 
@@ -62,14 +67,14 @@ Now we generate a collection of cloud files and process them using cloud streams
 
 // Generate 100 cloud files in the cloud storage
 let namedCloudFilesJob = 
-    [ for i in 1 .. 100 do 
+    [ for i in 1 .. 100 ->
         // Note that we generate the contents of the files in the cloud - this cloud
         // computation below only captures and sends an integer.
-        yield cloud { let lines = [for j in 1 .. 100 -> "File " + string i + ", Item " + string (i * 100 + j) + ", " + string (j + i * 100) ] 
-                      let nm = dp.Path + "/file" + string i
-                      do! CloudFile.Delete(path=nm) 
-                      return! CloudFile.WriteAllLines(lines,path=nm) 
-                      } ]
+        cloud { let lines = [for j in 1 .. 100 -> "File " + string i + ", Item " + string (i * 100 + j) + ", " + string (j + i * 100) ] 
+                let nm = dp.Path + "/file" + string i
+                do! CloudFile.Delete(path=nm) 
+                let! file = CloudFile.WriteAllLines(lines,path=nm) 
+                return file } ]
    |> Cloud.Parallel 
    |> cluster.CreateProcess
 
@@ -81,10 +86,10 @@ let namedCloudFiles = namedCloudFilesJob.AwaitResult()
 
 // Compute 
 let sumOfLengthsOfLinesJob =
-    let getLineCount (file : CloudFile) = local { let! lines = CloudFile.ReadAllLines file in return lines.Length }
-    let combineLineCounts c1 c2 = local { return c1 + c2 }
     namedCloudFiles 
-    |> Distributed.mapReduce getLineCount combineLineCounts 0
+    |> CloudStream.ofCloudFiles CloudFileReader.ReadAllLines
+    |> CloudStream.map (fun lines -> lines.Length)
+    |> CloudStream.sum
     |> cluster.CreateProcess
 
 

--- a/src/Demos/999-cloud-file-perf.fsx
+++ b/src/Demos/999-cloud-file-perf.fsx
@@ -47,8 +47,9 @@ let lineWritePerf, bigCloudTextFiles =
     timeSizes [ 1; 10; 100 ] <| fun sz -> 
         cloud { let lines = [| for i in 0 .. 10000 * sz-> "Some text that takes about one hundred bytes to store in default encoding if you look you can check" |] 
                 // This delete is needed because of https://github.com/mbraceproject/MBrace.Azure/issues/21
-                do! cloud { try do! CloudFile.Delete(path=dp.Path + sprintf "/big-lines-%d" sz) with _ -> () }
-                return! CloudFile.WriteAllLines(lines,path=dp.Path + sprintf "/big-lines-%d" sz)  }
+                do! CloudFile.Delete(path=dp.Path + sprintf "/big-lines-%d" sz) 
+                let! file = CloudFile.WriteAllLines(lines,path=dp.Path + sprintf "/big-lines-%d" sz)  
+                return file }
 
 // [(1, 0.6813008); (10, 1.200415); (100, 6.4491432)]
 // [(1, 1.133324); (10, 1.5016807); (100, 6.7401698)]
@@ -56,8 +57,9 @@ let textWritePerf, _ =
     timeSizes [ 1; 10; 100 ] <| fun sz -> 
         cloud { let text = System.String(' ', sz * 1024 * 1024)
                 // This delete is needed because of https://github.com/mbraceproject/MBrace.Azure/issues/21
-                do! cloud { try do! CloudFile.Delete(path=dp.Path + sprintf "/big-text-%d" sz) with _ -> () }
-                return! CloudFile.WriteAllText(text,path=dp.Path + sprintf "/big-text-%d" sz)  }
+                do! CloudFile.Delete(path=dp.Path + sprintf "/big-text-%d" sz) 
+                let! file = CloudFile.WriteAllText(text,path=dp.Path + sprintf "/big-text-%d" sz)  
+                return file }
 
 // #1   [(1, 0.5426625); (10, 2.0498235); (100, 21.1039728)]
 // #2   [(1, 0.8444004); (10, 1.9827996); (100, 21.1224367)]
@@ -67,8 +69,9 @@ let bytesWritePerf, bigCloudByteFiles =
     timeSizes [ 1; 10; 100; 1000 ] <| fun sz -> 
         cloud { let data = [| for i in 0 .. sz * 1024 * 1024 -> byte i |] 
                 // This delete is needed because of https://github.com/mbraceproject/MBrace.Azure/issues/21
-                do! cloud { try do! CloudFile.Delete(path=dp.Path + sprintf "/big-bytes-%d" sz) with _ -> () }
-                return! CloudFile.WriteAllBytes (data,path=dp.Path + sprintf "/big-bytes-%d" sz)  }
+                do! CloudFile.Delete(path=dp.Path + sprintf "/big-bytes-%d" sz) 
+                let! file = CloudFile.WriteAllBytes (data,path=dp.Path + sprintf "/big-bytes-%d" sz)  
+                return file }
 
 // #1   [(1, 3.1591611); (10, 0.5312207); (100, 3.0732776)]
 // #2   [(1, 0.2813198); (10, 0.4259485); (100, 2.6784925)]

--- a/src/Demos/999-misc-cpu-perf.fsx
+++ b/src/Demos/999-misc-cpu-perf.fsx
@@ -1,0 +1,79 @@
+﻿#load "credentials.fsx"
+#load "lib/collections.fsx"
+#load "lib/sieve.fsx"
+
+open System
+open System.IO
+open MBrace
+open MBrace.Azure
+open MBrace.Azure.Client
+open MBrace.Azure.Runtime
+open MBrace.Streams
+open MBrace.Workflows
+open Nessos.Streams
+
+(**
+
+ More advanced comparisons.
+
+ In each case, you still calculate a whole bunch of primes.
+
+**)
+
+// First connect to the cluster
+let cluster = Runtime.GetHandle(config)
+
+// Run in the cluster, single threaded, on a single random worker.
+//
+// This doesn't exploit the multiple worker nor multiple cores in the cluster, but gives you an
+// idea of the raw performance of the machines in the  cluster. Performance
+// will depend on the specification of your machines in the cluster.
+//
+// Sample time: Real: 00:00:42.830, CPU: 00:00:03.843, GC gen0: 72, gen1: 11, gen2: 0
+let clusterSingleMachineSingleThreaded =
+    cloud { 
+     return numbers |> Array.map(fun n -> 
+             let primes = Sieve.getPrimes n 
+             sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()))
+     } |>  cluster.Run
+
+
+// Run in the cluster, on a single randome worker, multi-threaded. This exploits the
+// mutli-core nature of a single random machine in the cluster.  Performance
+// will depend on the specification of your machines in the cluster.
+//
+// Sample time: Real: 00:00:24.236, CPU: 00:00:03.000, GC gen0: 53, gen1: 10, gen2: 0
+let clusterSingleWorkerMultiThreaded =
+    cloud { 
+     return 
+       numbers
+       |> Array.splitInto System.Environment.ProcessorCount
+       |> Array.Parallel.collect(fun nums -> 
+         [| for n in nums do 
+             let primes = Sieve.getPrimes n 
+             yield sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()) |])
+     } |>  cluster.Run
+
+// Run in the cluster, on multiple workers, each multi-threaded. This exploits the
+// the multiple machines (workers) in the cluster and each worker is running multi-threaded.
+//
+// We do the partitioning up-front.  
+//
+// Sample time: Real: 00:00:11.475, CPU: 00:00:01.921, GC gen0: 22, gen1: 12, gen2: 0
+let clusterMultiWorkerMultiThreaded =
+    numbers
+    |> Array.splitInto clusterWorkerCount
+    |> Array.map(fun nums -> 
+         cloud { 
+           return
+               nums
+               |> Array.splitInto System.Environment.ProcessorCount
+               |> Array.Parallel.collect(fun nums -> 
+                 [| for n in nums do 
+                     let primes = Sieve.getPrimes n 
+                     yield sprintf "calculated %d primes: %A on thread %d" primes.Length primes (getThread()) |])
+          })
+    |> Cloud.Parallel
+    |> cluster.Run
+
+

--- a/src/Demos/999-process-create-perf.fsx
+++ b/src/Demos/999-process-create-perf.fsx
@@ -13,11 +13,15 @@ open Nessos.Streams
 let cluster = Runtime.GetHandle(config)
 
 let ps = 
- [for i in 0 .. 10000 ->
-   printfn "starting %d, time = %A" i System.DateTime.Now.TimeOfDay
+ [let time = ref System.DateTime.Now.TimeOfDay
+  for i in 0 .. 10000 ->
+   let newTime = System.DateTime.Now.TimeOfDay
+   printfn "starting %d, diff = %A" i (time.Value - newTime)
+   time := newTime
    cloud { return System.DateTime.Now }
     |> cluster.CreateProcess ]
 
 cluster.ShowProcesses()
+
 
 

--- a/src/Demos/Demos.fsproj
+++ b/src/Demos/Demos.fsproj
@@ -71,10 +71,12 @@
     <None Include="10-using-cloud-atoms.fsx" />
     <None Include="11-distributed-multicore-parallel-search.fsx" />
     <None Include="12-norvig%27s-spelling-corrector.fsx" />
+    <None Include="13-creating-new-serialized-things.fsx" />
     <None Include="credentials.fsx" />
     <None Include="lib\collections.fsx" />
     <None Include="lib\sieve.fsx" />
     <None Include="lib\mersenne.fsx" />
+    <None Include="999-using-other-cloud-assets.fsx" />
     <None Include="999-cloud-file-perf.fsx" />
     <None Include="999-process-create-perf.fsx" />
   </ItemGroup>

--- a/src/Demos/Demos.fsproj
+++ b/src/Demos/Demos.fsproj
@@ -76,9 +76,9 @@
     <None Include="lib\collections.fsx" />
     <None Include="lib\sieve.fsx" />
     <None Include="lib\mersenne.fsx" />
-    <None Include="999-using-other-cloud-assets.fsx" />
     <None Include="999-cloud-file-perf.fsx" />
     <None Include="999-process-create-perf.fsx" />
+    <None Include="999-misc-cpu-perf.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />


### PR DESCRIPTION
This example shows how to build a transparently serializable base abstraction (like a CloudRef etc.)

I think this will be necessary when users want to build MBrace abstractions over other cloud assets
