### PR TITLE
remove namespaces

### DIFF
--- a/src/Demos/1-hello-world.fsx
+++ b/src/Demos/1-hello-world.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This demo shows how to send a simple computation to an mbrace cluster

--- a/src/Demos/10-using-cloud-atoms.fsx
+++ b/src/Demos/10-using-cloud-atoms.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This tutorial illustrates creating and using cloud atoms, which allow you to store data transactionally

--- a/src/Demos/11-distributed-multicore-parallel-search.fsx
+++ b/src/Demos/11-distributed-multicore-parallel-search.fsx
@@ -7,10 +7,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  In this tutorial you learn how to use Cloud.Choice to do a nondeterministic parallel computation using 

--- a/src/Demos/12-norvig's-spelling-corrector.fsx
+++ b/src/Demos/12-norvig's-spelling-corrector.fsx
@@ -8,7 +8,6 @@ open System.Text.RegularExpressions
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
 open Nessos.Streams

--- a/src/Demos/2-distributing-work.fsx
+++ b/src/Demos/2-distributing-work.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This demo shows how to start performing distributed workloads on MBrace clusters.

--- a/src/Demos/3-comparing-threads-and-workers.fsx
+++ b/src/Demos/3-comparing-threads-and-workers.fsx
@@ -7,10 +7,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This demo illustrates the different way of calculating scalable workloads

--- a/src/Demos/4-parallel-web-download.fsx
+++ b/src/Demos/4-parallel-web-download.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This demo illustrates doing I/O tasks in parallel using the workers in the cluster

--- a/src/Demos/5-cloud-streams.fsx
+++ b/src/Demos/5-cloud-streams.fsx
@@ -6,10 +6,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This tutorial illustrates using the CloudStream programming model that is part of MBrace for cloud-scheduled

--- a/src/Demos/6-nuget-packages.fsx
+++ b/src/Demos/6-nuget-packages.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This tutorial illustrates using other nuget packages.  You download and reference the packages as normal

--- a/src/Demos/7-using-cloud-data.fsx
+++ b/src/Demos/7-using-cloud-data.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This tutorial illustrates uploading data to Azure Blob Storage using CloudRef and CloudArray and then using the data.

--- a/src/Demos/8-using-cloud-files.fsx
+++ b/src/Demos/8-using-cloud-files.fsx
@@ -5,10 +5,8 @@ open System.IO
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This tutorial illustrates creating and using cloud files, and then processing them using cloud streams.

--- a/src/Demos/9-using-cloud-channels.fsx
+++ b/src/Demos/9-using-cloud-channels.fsx
@@ -6,10 +6,8 @@ open System.Collections.Generic
 open MBrace
 open MBrace.Azure
 open MBrace.Azure.Client
-open MBrace.Azure.Runtime
 open MBrace.Streams
 open MBrace.Workflows
-open Nessos.Streams
 
 (**
  This tutorial illustrates creating and using cloud channels, which allow you to send messages between


### PR DESCRIPTION
These namespaces are not really part of the MBrace client programming model, best to remove them. Nessos.Streams is removed in one place but AFAIK @palladin is working on trimming that from the client programming model
